### PR TITLE
Add pdqx executable stub

### DIFF
--- a/app/pdqx/Main.hs
+++ b/app/pdqx/Main.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = putStrLn "hello world"

--- a/hdt.cabal
+++ b/hdt.cabal
@@ -81,3 +81,12 @@ executable hdtview
 
     hs-source-dirs:   app
     default-language: Haskell2010
+
+executable pdqx
+    import:           warnings
+    main-is:          Main.hs
+    build-depends:
+        base
+
+    hs-source-dirs:   app/pdqx
+    default-language: Haskell2010


### PR DESCRIPTION
## Summary
- register a new pdqx executable in the Cabal configuration
- add a pdqx Main module that currently prints "hello world"

## Testing
- cabal build pdqx *(fails: `cabal` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c882f539408331a4223e4c58029b69