### PR TITLE
Implement pdqx CLI for loading PdQ files

### DIFF
--- a/app/pdqx/Main.hs
+++ b/app/pdqx/Main.hs
@@ -1,4 +1,45 @@
 module Main (main) where
 
+import Data.Semigroup ((<>))
+import Options.Applicative
+  ( Parser,
+    ParserInfo,
+    execParser,
+    fullDesc,
+    help,
+    helper,
+    info,
+    metavar,
+    progDesc,
+    strArgument,
+    (<**>)
+  )
+import PdQ (PdQ, getPdQ)
+
+newtype Options = Options
+  { pdqFile :: FilePath
+  }
+
+optionsParser :: Parser Options
+optionsParser =
+  Options
+    <$> strArgument
+      ( metavar "PDQ_FILE"
+          <> help "Path to the .pdq file"
+      )
+
+optionsInfo :: ParserInfo Options
+optionsInfo =
+  info
+    (optionsParser <**> helper)
+    ( fullDesc
+        <> progDesc "Inspect PdQ files by printing their parsed representation"
+    )
+
+run :: Options -> IO ()
+run opts = do
+  pdq :: PdQ <- getPdQ (pdqFile opts)
+  print pdq
+
 main :: IO ()
-main = putStrLn "hello world"
+main = execParser optionsInfo >>= run

--- a/hdt.cabal
+++ b/hdt.cabal
@@ -86,7 +86,9 @@ executable pdqx
     import:           warnings
     main-is:          Main.hs
     build-depends:
-        base
+        base,
+        optparse-applicative,
+        hdt
 
     hs-source-dirs:   app/pdqx
     default-language: Haskell2010


### PR DESCRIPTION
## Summary
- add an optparse-applicative CLI that accepts a positional .pdq file argument for pdqx
- load and display the parsed PdQ data using the existing getPdQ helper
- update pdqx executable dependencies to include optparse-applicative and reuse the hdt library

## Testing
- `cabal build pdqx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c88ebad15c83318def1ddd23b02053