### PR TITLE
Add selective pdqx output options

### DIFF
--- a/app/pdqx/Main.hs
+++ b/app/pdqx/Main.hs
@@ -1,5 +1,9 @@
 module Main (main) where
 
+import Control.Arrow ((>>>))
+import Control.Monad (when)
+import Data.Char (isSpace)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Semigroup ((<>))
 import Options.Applicative
   ( Parser,
@@ -9,15 +13,23 @@ import Options.Applicative
     help,
     helper,
     info,
+    long,
     metavar,
     progDesc,
+    short,
     strArgument,
+    switch,
     (<**>),
   )
-import PdQ (PdQ, getPdQ)
+import PdQ (Bookmark (..), Note (..), PdQ (..), getPdQ)
+import Text.XML.HXT.Core (arrL, constA, deep, getText, runX)
 
-newtype Options = Options
-  { pdqFile :: FilePath
+data Options = Options
+  { pdqFile :: FilePath,
+    showSummary :: Bool,
+    showNotes :: Bool,
+    showBookmarks :: Bool,
+    showTags :: Bool
   }
 
 optionsParser :: Parser Options
@@ -26,6 +38,26 @@ optionsParser =
     <$> strArgument
       ( metavar "PDQ_FILE"
           <> help "Path to the .pdq file"
+      )
+    <*> switch
+      ( short 's'
+          <> long "summary"
+          <> help "Print the PdQ summary"
+      )
+    <*> switch
+      ( short 'n'
+          <> long "notes"
+          <> help "Print PdQ notes"
+      )
+    <*> switch
+      ( short 'b'
+          <> long "bookmarks"
+          <> help "Print PdQ bookmarks"
+      )
+    <*> switch
+      ( short 't'
+          <> long "tags"
+          <> help "Print PdQ tags"
       )
 
 optionsInfo :: ParserInfo Options
@@ -39,7 +71,34 @@ optionsInfo =
 run :: Options -> IO ()
 run opts = do
   pdq <- getPdQ (pdqFile opts)
-  print pdq
+  let anySelector = or [showSummary opts, showNotes opts, showBookmarks opts, showTags opts]
+  if not anySelector
+    then print pdq
+    else do
+      when (showSummary opts) $ printSummary pdq
+      when (showNotes opts) $ printNotes pdq
+      when (showBookmarks opts) $ printBookmarks pdq
+      when (showTags opts) $ printTags pdq
 
 main :: IO ()
 main = execParser optionsInfo >>= run
+
+printSummary :: PdQ -> IO ()
+printSummary pdq =
+  case summary pdq of
+    Nothing -> pure ()
+    Just trees -> do
+      fragments <- runX (constA trees >>> arrL id >>> deep getText)
+      mapM_ putStrLn (filter (any (not . isSpace)) fragments)
+
+printNotes :: PdQ -> IO ()
+printNotes pdq =
+  mapM_ putStrLn . filter (any (not . isSpace)) . mapMaybe note $ fromMaybe [] (notes pdq)
+
+printBookmarks :: PdQ -> IO ()
+printBookmarks pdq =
+  mapM_ (\b -> putStrLn $ title b ++ " (page " ++ show (bookmarkPage b) ++ ")") $ fromMaybe [] (bookmarks pdq)
+
+printTags :: PdQ -> IO ()
+printTags pdq =
+  mapM_ putStrLn $ fromMaybe [] (tags pdq)

--- a/hdt.cabal
+++ b/hdt.cabal
@@ -88,7 +88,8 @@ executable pdqx
     build-depends:
         base,
         optparse-applicative,
-        hdt
+        hdt,
+        hxt
 
     hs-source-dirs:   app/pdqx
     default-language: Haskell2010


### PR DESCRIPTION
## Summary
- add pdqx CLI switches to print only the summary, notes, bookmarks, or tags from a PdQ file
- format note, bookmark, and tag output to show only the requested information
- add the hxt dependency to the pdqx executable to support summary extraction

## Testing
- `cabal build pdqx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b971c0408331aa9ae89c31b93ccc