### PR TITLE
Adjust default pdqx output

### DIFF
--- a/app/pdqx/Main.hs
+++ b/app/pdqx/Main.hs
@@ -73,7 +73,7 @@ run opts = do
   pdq <- getPdQ (pdqFile opts)
   let anySelector = or [showSummary opts, showNotes opts, showBookmarks opts, showTags opts]
   if not anySelector
-    then print pdq
+    then printDefault opts pdq
     else do
       when (showSummary opts) $ printSummary pdq
       when (showNotes opts) $ printNotes pdq
@@ -82,6 +82,13 @@ run opts = do
 
 main :: IO ()
 main = execParser optionsInfo >>= run
+
+printDefault :: Options -> PdQ -> IO ()
+printDefault opts pdq = do
+  putStrLn (pdqFile opts)
+  printSummary pdq
+  printBookmarks pdq
+  printNotes pdq
 
 printSummary :: PdQ -> IO ()
 printSummary pdq =


### PR DESCRIPTION
## Summary
- ensure pdqx prints the file path, summary, bookmarks, and notes when run without switches
- add a helper to encapsulate the default output order

## Testing
- `cabal build pdqx` *(fails: cabal command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b838110c8331b12be67210eefb38