### PR TITLE
Bold default pdqx path and summary

### DIFF
--- a/app/pdqx/Main.hs
+++ b/app/pdqx/Main.hs
@@ -22,6 +22,11 @@ import Options.Applicative
     (<**>),
   )
 import PdQ (Bookmark (..), Note (..), PdQ (..), getPdQ)
+import System.Console.ANSI
+  ( ConsoleIntensity (BoldIntensity),
+    SGR (Reset, SetConsoleIntensity),
+    setSGRCode
+  )
 import Text.XML.HXT.Core (arrL, constA, deep, getText, runX)
 
 data Options = Options
@@ -95,7 +100,15 @@ printDefault opts pdq = do
             ("Bookmarks", bookmarksSection),
             ("Notes", notesSection)
           ]
-  printSections sections
+      highlighted = map highlight sections
+  printSections highlighted
+  where
+    highlight section@(title, contents)
+      | title `elem` ["Path", "Summary"] = (title, map bold contents)
+      | otherwise = section
+
+bold :: String -> String
+bold text = setSGRCode [SetConsoleIntensity BoldIntensity] ++ text ++ setSGRCode [Reset]
 
 printSections :: [(String, [String])] -> IO ()
 printSections [] = pure ()

--- a/hdt.cabal
+++ b/hdt.cabal
@@ -87,6 +87,7 @@ executable pdqx
     main-is:          Main.hs
     build-depends:
         base,
+        ansi-terminal,
         optparse-applicative,
         hdt,
         hxt


### PR DESCRIPTION
## Summary
- highlight the default pdqx path and summary output using ANSI bold formatting
- add ansi-terminal as a dependency for the pdqx executable

## Testing
- `cabal build pdqx` *(fails: `cabal` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c3d1e2088331842cb2d9d4c53add