### PR TITLE
Add pdqmatch executable for parsing PdQ files

### DIFF
--- a/app/pdqmatch/Main.hs
+++ b/app/pdqmatch/Main.hs
@@ -1,0 +1,16 @@
+module Main (main) where
+
+import Control.Monad (void)
+import Data.Char (isSpace)
+import Data.List (dropWhileEnd)
+import PdQ (getPdQ)
+
+main :: IO ()
+main = do
+  contents <- getContents
+  let files = map strip (lines contents)
+      valid = filter (not . null) files
+  mapM_ (void . getPdQ) valid
+
+strip :: String -> String
+strip = dropWhile isSpace . dropWhileEnd isSpace

--- a/hdt.cabal
+++ b/hdt.cabal
@@ -94,3 +94,13 @@ executable pdqx
 
     hs-source-dirs:   app/pdqx
     default-language: Haskell2010
+
+executable pdqmatch
+    import:           warnings
+    main-is:          Main.hs
+    build-depends:
+        base,
+        hdt
+
+    hs-source-dirs:   app/pdqmatch
+    default-language: Haskell2010


### PR DESCRIPTION
## Summary
- add a new `pdqmatch` executable that reads `.pdq` paths from stdin and loads their PdQ data
- register the executable in the Cabal configuration so it is built with the project

## Testing
- `cabal build pdqmatch` *(fails: `cabal` is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e1da49188331ba91f0350eab91a6