### PR TITLE
Add CLI summary filter to pdqmatch

### DIFF
--- a/app/pdqmatch/Main.hs
+++ b/app/pdqmatch/Main.hs
@@ -1,16 +1,70 @@
 module Main (main) where
 
+import Control.Arrow ((>>>))
 import Control.Monad (void)
 import Data.Char (isSpace)
-import Data.List (dropWhileEnd)
-import PdQ (getPdQ)
+import Data.List (dropWhileEnd, intercalate)
+import Data.Maybe (catMaybes)
+import Data.Semigroup ((<>))
+import qualified Options.Applicative as Opt
+import Options.Applicative ((<**>))
+import PdQ (PdQ (..), getPdQ)
+import Text.XML.HXT.Core (arrL, constA, deep, getText, runX)
+
+data Options = Options
+  { summaryQuery :: Maybe String
+  }
+
+optionsParser :: Opt.Parser Options
+optionsParser =
+  Options
+    <$> Opt.optional
+      ( Opt.strOption
+          ( Opt.short 's'
+              <> Opt.long "summary"
+              <> Opt.metavar "SUMMARY"
+              <> Opt.help "Print PdQ file paths whose summary matches SUMMARY"
+          )
+      )
+
+optionsInfo :: Opt.ParserInfo Options
+optionsInfo =
+  Opt.info
+    (optionsParser <**> Opt.helper)
+    ( Opt.fullDesc
+        <> Opt.progDesc "Read PdQ file paths from stdin and optionally match their summaries"
+    )
 
 main :: IO ()
 main = do
+  opts <- Opt.execParser optionsInfo
   contents <- getContents
   let files = map strip (lines contents)
       valid = filter (not . null) files
-  mapM_ (void . getPdQ) valid
+  case summaryQuery opts of
+    Nothing -> mapM_ (void . getPdQ) valid
+    Just query -> do
+      let normalizedQuery = strip query
+      matches <- mapM (matchSummary normalizedQuery) valid
+      mapM_ putStrLn (catMaybes matches)
+
+matchSummary :: String -> FilePath -> IO (Maybe FilePath)
+matchSummary query path = do
+  pdq <- getPdQ path
+  mSummary <- extractSummary pdq
+  pure $ case mSummary of
+    Just summaryText | summaryText == query -> Just path
+    _ -> Nothing
+
+extractSummary :: PdQ -> IO (Maybe String)
+extractSummary pdq =
+  case summary pdq of
+    Nothing -> pure Nothing
+    Just trees -> do
+      fragments <- runX (constA trees >>> arrL id >>> deep getText)
+      let trimmed = filter (not . null) (map strip fragments)
+          text = strip (intercalate "\n" trimmed)
+      if null text then pure Nothing else pure (Just text)
 
 strip :: String -> String
 strip = dropWhile isSpace . dropWhileEnd isSpace

--- a/hdt.cabal
+++ b/hdt.cabal
@@ -100,7 +100,9 @@ executable pdqmatch
     main-is:          Main.hs
     build-depends:
         base,
-        hdt
+        hdt,
+        hxt,
+        optparse-applicative
 
     hs-source-dirs:   app/pdqmatch
     default-language: Haskell2010


### PR DESCRIPTION
## Summary
- parse stdin-fed PdQ file paths while using optparse-applicative for option handling
- add a -s/--summary option that prints the path of PdQ files whose summary text matches the provided query
- extract textual summaries from PdQ documents and add the required executable dependencies

## Testing
- `cabal build pdqmatch` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e4be8ef08331bc668dc4e8c19ab9